### PR TITLE
Unlock ancient pytz version (causes conflicts)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,5 +25,5 @@ setup(name='timestring',
       packages=['timestring'],
       include_package_data=True,
       zip_safe=True,
-      install_requires=["pytz==2013b"],
+      install_requires=["pytz"],
       entry_points={'console_scripts': ['timestring=timestring:main']})


### PR DESCRIPTION
per python specs, versioning should never be in setup.py, only requirements.txt (anti-pattern)