### PR TITLE
Fork the project on pypi, bump the version

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,3 @@
+include README.md
+include LICENSE.txt
+include requirements.txt

--- a/README.md
+++ b/README.md
@@ -1,10 +1,15 @@
-# timestring [![Build Status](https://secure.travis-ci.org/stevepeak/timestring.png)](http://travis-ci.org/stevepeak/timestring) [![Version](https://pypip.in/v/timestring/badge.png)](https://github.com/stevepeak/timestring) [![codecov.io](https://codecov.io/github/stevepeak/timestring/coverage.svg?branch=master)](https://codecov.io/github/stevepeak/timestring)
+# timestring [![Build Status](https://secure.travis-ci.org/iamplus/timestring.png)](http://travis-ci.org/iamplus/timestring) [![Version](https://pypip.in/v/timestring/badge.png)](https://github.com/iamplus/timestring) [![codecov.io](https://codecov.io/github/iamplus/timestring/coverage.svg?branch=master)](https://codecov.io/github/iamplus/timestring)
 
-Converting strings into usable time objects. The time objects, known as `Date` and `Range` have a number of methods that allow 
-you to easily change and manage your users input dynamically.
+## Origins
+This is a fork of github.com/stevepeak/timestring. The original author
+appears to no longer be maintaining the code.
+
+Converting strings into usable time objects. The time objects, known as
+`Date` and `Range` have a number of methods that allow you to easily
+change and manage your users input dynamically.
 
 ## Install
-`pip install timestring`
+`pip install timestring-iamplus`
 
 
 ## Ranges
@@ -49,7 +54,7 @@ From 01/01/11 00:00:00 to 01/01/12 00:00:00
 
 *Note* you add more years like this `5 years ago` which will be `From 01/01/07 00:00:00 to 01/01/08 00:00:00`
 
-### See examples see the [test file](https://github.com/stevepeak/timestring/blob/master/tests/tests.py)
+### See examples see the [test file](https://github.com/iamplus/timestring/blob/master/tests/tests.py)
 
 More examples / documentation coming soon.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+description-file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python
 from setuptools import setup
 
-version = '1.6.2'
+version = '1.6.5'
+
 classifiers = ["Development Status :: 5 - Production/Stable",
                "License :: OSI Approved :: Apache Software License",
                "Programming Language :: Python",
@@ -9,18 +10,25 @@ classifiers = ["Development Status :: 5 - Production/Stable",
                "Programming Language :: Python :: 2.7",
                "Programming Language :: Python :: 3.2",
                "Programming Language :: Python :: 3.3",
-               "Programming Language :: Python :: Implementation :: PyPy"]   
+               "Programming Language :: Python :: Implementation :: PyPy"]
 
-setup(name='timestring',
+setup(name='timestring-iamplus',
       version=version,
       description="Human expressed time to Dates and Ranges",
-      long_description="""Converting strings of into representable time via Date and Range objects.
- Plus features to compare and adjust Dates and Ranges.""",
+      long_description="""
+[Fork and active maintenance of github.com/stevepeak/timestring.]
+
+Converting natural language strings into representable time via
+Date and Range objects and features to compare and adjust
+Dates and Ranges. Dates and Ranges contain datetime compatible
+objects inside them to allow for easy integration into legacy
+code.
+""",
       classifiers=classifiers,
       keywords='date time range datetime datestring',
-      author='@stevepeak',
+      author='@stevepeak, @iamplus (fork)',
       author_email='steve@stevepeak.net',
-      url='http://github.com/stevepeak/timestring',
+      url='http://github.com/iamplus/timestring',
       license='http://www.apache.org/licenses/LICENSE-2.0',
       packages=['timestring'],
       include_package_data=True,


### PR DESCRIPTION
Since Steve doesn't seem to be maintaining timestring anymore despite several
attempts to contact him, I suggest that we create a pypi accessible fork until
such time as he begins responding again.

This commit sets us up so that you can publish your own timestring-iamplus version.
You will need to register with pypi and publish.

If you don't agree, I'll publish my own fork again (I did based upon Steve's work, but I've now re-homed to your version).