### PR TITLE
Fix Date and tests for Range

### DIFF
--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -11,7 +11,6 @@ from timestring.Range import Range, CONTEXT_PAST, CONTEXT_FUTURE
 @freeze_time('2017-06-16 19:37:22')
 class RangeTest(unittest.TestCase):
     def assert_range(self, range_str, expected_start: datetime,
-                     expected_end: datetime):
                      expected_end: datetime, context=None):
         _range = Range(range_str, context=context)
 
@@ -105,7 +104,7 @@ class RangeTest(unittest.TestCase):
                           datetime(2017,  6,  16, 12,  0,  0))
 
 
-    def test_context_past_future(self):
+    def test_context(self):
         # Current period
         self.assert_range('2017',
                           datetime(2017, 1, 1),
@@ -148,12 +147,12 @@ class RangeTest(unittest.TestCase):
                           datetime(2001, 1, 1),
                           context=CONTEXT_FUTURE)
 
-        self.assert_range('may',
+        self.assert_range('last may',
                           datetime(2017, 5, 1),
                           datetime(2017, 6, 1),
                           context=CONTEXT_PAST)
 
-        self.assert_range('may',
+        self.assert_range('last may',
                           datetime(2017, 5, 1),
                           datetime(2017, 6, 1),
                           context=CONTEXT_FUTURE)

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -13,7 +13,6 @@ class RangeTest(unittest.TestCase):
     def assert_range(self, range_str, expected_start: datetime,
                      expected_end: datetime):
         _range = Range(range_str)
-
         self.assertEqual(_range.start,
                          expected_start,
                         '\n          Text: ' + range_str
@@ -34,7 +33,7 @@ class RangeTest(unittest.TestCase):
             'sep 5 2012',
             'sept 5 2012',
             "sep 5th, '12",
-            '5th September, 2012'
+            '5th September, 2012',
             #TODO: 5th of September, 2012
             '2012/9/5',
             '2012-09-5T',
@@ -110,11 +109,11 @@ class RangeTest(unittest.TestCase):
                           datetime(2017, 6, 17, 0, 0, 0))
 
         self.assert_range('11:59pm on Feb 28',
-                          datetime(2017, 2, 28, 23, 59, 0),
-                          datetime(2017, 3, 1, 0, 0, 0))
+                          datetime(2018, 2, 28, 23, 59, 0),
+                          datetime(2018, 3, 1, 0, 0, 0))
 
-        self.assert_range('11pm on dec 31',
-                          datetime(2017, 12, 31, 23, 0, 0),
+        self.assert_range('11:59pm on dec 31',
+                          datetime(2017, 12, 31, 23, 59, 0),
                           datetime(2018, 1, 1, 0, 0, 0))
 
     def test_explicit_end(self):
@@ -127,12 +126,12 @@ class RangeTest(unittest.TestCase):
                           datetime(2010, 1, 12))
 
         self.assert_range('january 10 to jan 12',
-                          datetime(2017, 1, 10),
-                          datetime(2017, 1, 12))
+                          datetime(2018, 1, 10),
+                          datetime(2018, 1, 12))
 
         self.assert_range('between january 10 and jan 12',
-                          datetime(2017, 1, 10),
-                          datetime(2017, 1, 12))
+                          datetime(2018, 1, 10),
+                          datetime(2018, 1, 12))
 
         self.assert_range('10am to 11pm',
                           datetime(2017, 6, 16, 10),

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,6 +5,8 @@ from ddt import ddt, data
 from six import u
 from datetime import datetime, timedelta
 
+from freezegun import freeze_time
+
 from timestring import Date
 from timestring import Range
 from timestring import parse
@@ -12,8 +14,18 @@ from timestring.text2num import text2num
 from timestring.timestring_re import TIMESTRING_RE as ts
 
 
+@freeze_time('2017-06-16 19:37:22')
 @ddt
 class timestringTests(unittest.TestCase):
+    def assert_date(self, date_str, expected: datetime):
+        actual = Date(date_str)
+
+        self.assertEqual(actual,
+                         expected,
+                         '\n    Text: ' + date_str
+                         + '\nExpected: ' + str(expected)
+                         + '\n  Actual: ' + str(actual))
+
     def test_fullstring(self):
         now = datetime.now()
 
@@ -432,6 +444,51 @@ class timestringTests(unittest.TestCase):
         self.assertNotEqual(res, None)
         res = ts.search("23rd feb 9:35pm")
         self.assertNotEqual(res, None)
+
+    def test_next_prev(self):
+        # Past month
+        self.assert_date('nov', datetime(2017, 11, 1))
+        self.assert_date('this nov', datetime(2017, 11, 1))
+        self.assert_date('last nov', datetime(2016, 11, 1))
+        self.assert_date('previous nov', datetime(2016, 11, 1))
+        self.assert_date('next nov', datetime(2017, 11, 1))
+        self.assert_date('upcoming nov', datetime(2017, 11, 1))
+
+        # Future month
+        self.assert_date('feb', datetime(2018, 2, 1))
+        self.assert_date('this feb', datetime(2018, 2, 1), )
+        self.assert_date('last feb', datetime(2017, 2, 1))
+        self.assert_date('previous feb', datetime(2017, 2, 1))
+        self.assert_date('next feb', datetime(2018, 2, 1))
+        self.assert_date('upcoming feb', datetime(2018, 2, 1))
+
+        # Current month
+        self.assert_date('june', datetime(2017, 6, 1))
+        self.assert_date('this june', datetime(2017, 6, 1))
+        self.assert_date('last june', datetime(2016, 6, 1))
+        self.assert_date('next june', datetime(2018, 6, 1))
+
+        # Past weekday
+        self.assert_date('sun', datetime(2017, 6, 18))
+        self.assert_date('this sun', datetime(2017, 6, 18))
+        self.assert_date('last sun', datetime(2017, 6, 11))
+        self.assert_date('previous sun', datetime(2017, 6, 11))
+        self.assert_date('next sun', datetime(2017, 6, 18))
+        self.assert_date('upcoming sun', datetime(2017, 6, 18))
+
+        # Future weekday
+        self.assert_date('wed', datetime(2017, 6, 21))
+        self.assert_date('last wed', datetime(2017, 6, 14))
+        self.assert_date('previous wed', datetime(2017, 6, 14))
+        self.assert_date('next wed', datetime(2017, 6, 21))
+        self.assert_date('upcoming wed', datetime(2017, 6, 21))
+
+        # Current weekday
+        self.assert_date('fri', datetime(2017, 6, 16))
+        self.assert_date('this fri', datetime(2017, 6, 16))
+        self.assert_date('last fri', datetime(2017, 6, 9))
+        self.assert_date('next fri', datetime(2017, 6, 23))
+
 
 def main():
     os.environ['TZ'] = 'UTC'

--- a/timestring/Date.py
+++ b/timestring/Date.py
@@ -168,9 +168,10 @@ class Date(object):
                 if month:
                     month_ = max(month)
                     if re.match('^\d+$', month_):
-                        month_ord = month_
+                        month_ord = int(month_)
                     else:
                         month_ord = MONTH_ORDINALS.get(month_, new_date.month)
+
                     new_date = new_date.replace(month=int(month_ord))
                     if ref in ['next', 'upcoming']:
                         if month_ord <= now.month:
@@ -178,7 +179,7 @@ class Date(object):
                     elif ref in ['last', 'previous', 'prev']:
                         if month_ord >= now.month:
                             new_date = new_date.replace(year=new_date.year - 1)
-                    elif month_ord < now.month:
+                    elif month_ord < now.month and not year:
                         new_date = new_date.replace(year=new_date.year + 1)
 
                 # !day
@@ -199,7 +200,6 @@ class Date(object):
                         new_date = new_date.replace(hour=dict(morning=9, noon=12, afternoon=15, evening=18, night=21, nighttime=21, midnight=24).get(date.get('daytime'), 12))
                     # No offset because the hour was set.
                     offset = False
-
 
                 # !hour
                 hour = [date.get(key) for key in ('hour', 'hour_2', 'hour_3') if date.get(key)]
@@ -223,7 +223,7 @@ class Date(object):
                     if seconds:
                         new_date = new_date.replace(second=int(seconds))
 
-                if dow is None and day == []:
+                if dow is None and not (day or hour):
                     new_date = new_date.replace(day=1)
                 if hour == [] and daytime is None:
                     new_date = new_date.replace(hour=0, minute=0, second=0)

--- a/timestring/Range.py
+++ b/timestring/Range.py
@@ -180,7 +180,6 @@ class Range(object):
                         start = start.replace(hour=0, minute=0, second=0)
                         if group['ref'] in ['last', 'prev', 'previous', 'past']:
                             start -= '1 year'
-                            print(start)
                         elif group['ref'] in ['next', 'upcoming'] and start.weekday == now.weekday:
                             start += '1 year'
                     end = start + '1 month'

--- a/timestring/Range.py
+++ b/timestring/Range.py
@@ -179,9 +179,10 @@ class Range(object):
                         start = Date(group['month_1'], offset=offset, tz=tz)
                         start = start.replace(hour=0, minute=0, second=0)
                         if group['ref'] in ['last', 'prev', 'previous', 'past']:
-                            start -= '1 month'
+                            start -= '1 year'
+                            print(start)
                         elif group['ref'] in ['next', 'upcoming'] and start.weekday == now.weekday:
-                            start += '1 month'
+                            start += '1 year'
                     end = start + '1 month'
 
                 elif group['date_5'] or group['date_6'] or group['time_2']:


### PR DESCRIPTION
* Fix bugs in Date
* Fix failing tests in `test_range.py`
* Add tests in `test_range.py`
* Re-add #19 which was reverted in #22, namely:
  * Consistent treatment of 'next', 'previous' etc for months
  * If not specified, default month=1, day=1, hour=0 etc.