### PR TITLE
AE-5391 Removing timestamp support

### DIFF
--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -76,11 +76,6 @@ class T(unittest.TestCase):
         # Offset timezone
         self.assertEqual(Date('2014-03-06 15:33:43.764419-05').hour, 20)
 
-    def test_timestamp(self):
-        ts = 1374681560
-        for param in ts, str(ts):
-            self.assert_date(param, datetime(2013, 7, 24, 8, 59, 20, 0))
-
     def test_exceptions(self):
         for x in ['yestserday', 'Satruday', Exception]:
             with self.assertRaises(TimestringInvalid):

--- a/tests/test_range.py
+++ b/tests/test_range.py
@@ -63,11 +63,6 @@ class T(unittest.TestCase):
 
         # TODO: 13/5/2012
 
-    def test_timestamp(self):
-        start, end = Range(1374681560)
-        self.assertEqual(start.day, 24)
-        self.assertEqual(end.day, 24)
-
     def test_exceptions(self):
         for date_str in ['yestserday', 'Satruday', Exception]:
             with self.assertRaises(TimestringInvalid):

--- a/timestring/Date.py
+++ b/timestring/Date.py
@@ -73,11 +73,6 @@ class Date(object):
         elif isinstance(date, datetime):
             self.date = date
 
-        elif isinstance(date, (int, long, float)) \
-                    or (isinstance(date, (str, unicode)) and date.isdigit()) \
-                and len(str(int(float(date)))) > 4:
-            self.date = datetime.fromtimestamp(int(date))
-
         elif date == 'now' or date is None:
             self.date = now
 

--- a/timestring/Range.py
+++ b/timestring/Range.py
@@ -50,13 +50,6 @@ class Range(object):
         elif start == 'infinity':
             self._dates = (Date('infinity'), Date('infinity'))
 
-        elif isinstance(start, (int, long, float)) \
-                    or (isinstance(start, (str, unicode)) and start.isdigit()) \
-                and len(str(int(float(start)))) > 4:
-            start = Date(start)
-            end = start + '1 second'
-            self._dates = start, end
-
         elif re.search(r'(\s(and|to)\s)', start):
             # Both sides are provided in string "start"
             start = re.sub('^(between|from)\s', '', start.lower())


### PR DESCRIPTION
datetime.fromtimestamp - the time in seconds since the epoch(January 1, 1970, 00:00:00 (UTC)) to datetime object. 
It is returning 1970-01-02 01:00:37 for input 90036.
Removing timestamp support to avoid wrong resolution in NLU.