### PR TITLE
NC-462 Record which parts of date were specified by user

### DIFF
--- a/tests/test_date.py
+++ b/tests/test_date.py
@@ -42,26 +42,26 @@ class T(unittest.TestCase):
             '5th of September, 2012',
         ]:
             self.assert_date(date_str, datetime(2012, 9, 5),
-                             Specified(1, 1, 1, 0, 0, 0, 0, 0))
+                             Specified(is_year=1, is_month=1, is_day=1))
 
         self.assert_date('2012', datetime(2012, 1, 1),
-                         Specified(1, 0, 0, 0, 0, 0, 0, 0))
+                         Specified(is_year=1))
         self.assert_date('January 2013', datetime(2013, 1, 1),
-                         Specified(1, 1, 0, 0, 0, 0, 0, 0))
+                         Specified(is_year=1, is_month=1))
         self.assert_date('feb 2011', datetime(2011, 2, 1),
-                         Specified(1, 1, 0, 0, 0, 0, 0, 0))
+                         Specified(is_year=1, is_month=1))
         self.assert_date('today', datetime(2017, 6, 16),
-                         Specified(0, 0, 1, 0, 0, 0, 0, 0))
+                         Specified(is_day=1))
         # TODO: 13/5/2012
 
     def test_time_formats(self):
         expected_datetime = datetime(2017, 6, 17, 11, 0, 0)
         for time_str in ['11am', '11 AM', '11a',]:
             self.assert_date(time_str, expected_datetime,
-                             Specified(0, 0, 0, 1, 1, 0, 0, 0))
+                             Specified(is_daytime=1, is_hour=1))
         for time_str in ["11 o'clock", '11 oclock',]:
             self.assert_date(time_str, expected_datetime,
-                             Specified(0, 0, 0, 0, 1, 0, 0, 0))
+                             Specified(is_hour=1))
             # TODO: at 11
             # TODO: eleven o'clock
             # TODO: 1100 hours
@@ -71,7 +71,7 @@ class T(unittest.TestCase):
             # TODO sep 5 11pm
             # TODO sep 5, 11pm
             self.assert_date(date_str, datetime(2017, 9, 5, 11, 0, 0),
-                             Specified(0, 1, 1, 1, 1, 0, 0, 0))
+                             Specified(is_month=1, is_day=1, is_daytime=1, is_hour=1))
 
         for date_str in [
             '09/05/2012 at 7:35pm'
@@ -87,7 +87,7 @@ class T(unittest.TestCase):
             "sep 5th '12 at 7:35:00 am"
         ]:
             self.assert_date(date_str, datetime(2012, 9, 5, 19, 35, 0),
-                             Specified(1, 1, 1, 1, 1, 1, 0, 0))
+                             Specified.all(is_second=0, is_microsecond=0))
 
         # Offset timezone
         d = Date('2014-03-06 15:33:43.764419-05')
@@ -97,68 +97,68 @@ class T(unittest.TestCase):
     def test_implicit(self):
         self.assert_date('2011 nov 11 at 11:11:11',
                          datetime(2011, 11, 11, 11, 11, 11),
-                         Specified(1, 1, 1, 0, 1, 1, 1, 0))
+                         Specified.all(is_daytime=0, is_microsecond=0))
 
         self.assert_date('2011 nov 11 at 11:11',
                          datetime(2011, 11, 11, 11, 11,  0),
-                         Specified(1, 1, 1, 0, 1, 1, 0, 0))
+                         Specified.all(is_daytime=0, is_second=0, is_microsecond=0))
 
         self.assert_date('2011 nov 11 at 11am',
                          datetime(2011, 11, 11, 11,  0,  0),
-                         Specified(1, 1, 1, 1, 1, 0, 0, 0))
+                         Specified.all(is_minute=0, is_second=0, is_microsecond=0))
 
         self.assert_date('2011 nov 11',
                          datetime(2011, 11, 11,  0,  0,  0),
-                         Specified(1, 1, 1, 0, 0, 0, 0, 0))
+                         Specified(is_year=1, is_month=1, is_day=1))
 
         self.assert_date('2011 nov',
                          datetime(2011, 11,  1,  0,  0,  0),
-                         Specified(1, 1, 0, 0, 0, 0, 0, 0))
+                         Specified(is_year=1, is_month=1))
 
         self.assert_date('2011',
                          datetime(2011,  1,  1,  0,  0,  0),
-                         Specified(1, 0, 0, 0, 0, 0, 0, 0))
+                         Specified(is_year=1))
 
         self.assert_date('nov 11 at 11:11:11',
                          datetime(2017, 11, 11, 11, 11, 11),
-                         Specified(0, 1, 1, 0, 1, 1, 1, 0))
+                         Specified.all(is_year=0, is_daytime=0, is_microsecond=0))
 
         self.assert_date('nov 11 at 11:11',
                          datetime(2017, 11, 11, 11, 11,  0),
-                         Specified(0, 1, 1, 0, 1, 1, 0, 0))
+                         Specified(is_month=1, is_day=1, is_hour=1, is_minute=1))
 
         self.assert_date('nov 11 at 11am',
                          datetime(2017, 11, 11, 11,  0,  0),
-                         Specified(0, 1, 1, 1, 1, 0, 0, 0))
+                         Specified(is_month=1, is_day=1, is_daytime=1, is_hour=1))
 
         self.assert_date('nov 11',
                          datetime(2017, 11, 11,  0,  0,  0),
-                         Specified(0, 1, 1, 0, 0, 0, 0, 0))
+                         Specified(is_month=1, is_day=1))
 
         self.assert_date('nov',
                          datetime(2017, 11,  1,  0,  0,  0),
-                         Specified(0, 1, 0, 0, 0, 0, 0, 0))
+                         Specified(is_month=1))
 
         self.assert_date('11:11:11',
                          datetime(2017,  6,  17, 11, 11, 11),
-                         Specified(0, 0, 0, 0, 1, 1, 1, 0))
+                         Specified(is_hour=1, is_minute=1, is_second=1))
 
         self.assert_date('11:11',
                          datetime(2017,  6,  17, 11, 11,  0),
-                         Specified(0, 0, 0, 0, 1, 1, 0, 0))
+                         Specified(is_hour=1, is_minute=1))
 
         self.assert_date('11am',
                          datetime(2017,  6,  17, 11,  0,  0),
-                         Specified(0, 0, 0, 1, 1, 0, 0, 0))
+                         Specified(is_daytime=1, is_hour=1))
 
         self.assert_date("11 o'clock",
                          datetime(2017, 6, 17, 11, 0, 0),
-                         Specified(0, 0, 0, 0, 1, 0, 0, 0)
+                         Specified(is_hour=1)
                          )
 
         self.assert_date('morning',
                          datetime(2017, 6, 16, DAYTIMES['morning'], 0, 0),
-                         Specified(0, 0, 0, 1, 0, 0, 0, 0))
+                         Specified(is_daytime=1))
 
     def test_exceptions(self):
         for x in ['yestserday', 'Satruday', Exception]:
@@ -172,25 +172,25 @@ class T(unittest.TestCase):
             self.assertLess(d.date - now, timedelta(7), day)
             self.assertEqual(d.weekday, i, day)
             self.assertEqual(d.isoweekday, 1 + i, day)
-            self.assertEqual(d.specified, Specified(0, 0, 1, 0, 0, 0, 0, 0))
+            self.assertEqual(d.specified, Specified(is_day=1))
 
     def test_offset(self):
         self.assert_date(
             'now',
             datetime(2017, 6, 16, 19, 3, 22),
-            Specified(1, 1, 1, 1, 1, 1, 1, 1),
+            Specified.all(),
             offset=dict(minute=3)
         )
         self.assert_date(
             'today',
             datetime(2017, 6, 5, 4, 3, 2, 1),
-            Specified(0, 0, 1, 0, 0, 0, 0, 0),
+            Specified(is_day=1),
             offset=dict(day=5, hour=4, minute=3, second=2, microsecond=1)
         )
         self.assert_date(
             'yesterday',
             datetime(2017, 6, 1, 2, 3, 4, 5),
-            Specified(0, 0, 1, 0, 0, 0, 0, 0),
+            Specified(is_day=1),
             offset=dict(day=1, hour=2, minute=3, second=4, microsecond=5)
         )
         self.assertEqual(Date('august 25th 7:30am', offset=dict(hour=10)).hour, 7)
@@ -205,13 +205,13 @@ class T(unittest.TestCase):
         date_2.microsecond = 1
         date_3 = date_1 + '1 day'
         self.assertEqual(date_3, date_2)
-        self.assertEqual(date_3.specified, Specified(0, 1, 1, 0, 0, 0, 0, 0),
+        self.assertEqual(date_3.specified, Specified(is_month=1, is_day=1),
                          date_3.specified)
 
         date1 = Date('october 18, 2013 10:04:32 PM')
         date2 = date1 + '10 seconds'
         self.assertEqual(date1.second + 10, date2.second)
-        self.assertEqual(date2.specified, Specified(1, 1, 1, 1, 1, 1, 1, 0))
+        self.assertEqual(date2.specified, Specified.all(is_microsecond=0))
 
     def test_minus(self):
         date_1 = Date('jan 10')
@@ -220,7 +220,7 @@ class T(unittest.TestCase):
         date_2.microsecond = 1
         date_3 = Date(date_1) - '5 days'
         self.assertEqual(date_3, date_2)
-        self.assertEqual(date_3.specified, Specified(0, 1, 1, 0, 0, 0, 0, 0))
+        self.assertEqual(date_3.specified, Specified(is_month=1, is_day=1))
 
     def test_adjustment(self):
         d = Date('Jan 1st 2014 at 10 am')

--- a/timestring/Date.py
+++ b/timestring/Date.py
@@ -56,26 +56,21 @@ TIMEDELTA_UNITS = dict(
 
 
 class Specified:
-    def __init__(self, year, month, day, hour, minute, second, microsecond):
+    def __init__(self, year, month, day, daytime, hour, minute, second, microsecond):
         self.year = year
         self.month = month
         self.day = day
+        self.daytime = daytime
         self.hour = hour
         self.minute = minute
         self.second = second
         self.microsecond = microsecond
 
-    def is_date(self):
-        return self.year and self.month and self.day
-
-    def is_time(self):
-        return self.hour and self.minute and self.second
-
 
 class Date(object):
     def __init__(self, date=None, offset: dict = None, tz: str = None,
                  now: datetime = None, verbose=False, context=None):
-        self._specified = Specified(0, 0, 0, 0, 0, 0, 0)
+        self._specified = Specified(0, 0, 0, 0, 0, 0, 0, 0)
         self._original = date
         if tz:
             tz = pytz.timezone(str(tz))
@@ -124,7 +119,7 @@ class Date(object):
 
                 if date.get('unixtime'):
                     new_date = datetime.fromtimestamp(int(date.get('unixtime')))
-                    self._specified = Specified(1, 1, 1, 1, 1, 1, 1)
+                    self._specified = Specified(1, 1, 1, 1, 1, 1, 1, 1)
 
                 # Number of (days|...) [ago]
                 elif num and unit:
@@ -216,17 +211,19 @@ class Date(object):
                                                     microsecond=0)
                     # No offset because the hour was set.
                     offset = False
-                    self._specified.hour = True  # TODO am/pm
+                    self._specified.daytime = True
 
                 # Hour
                 hour = [date.get(key) for key in ('hour', 'hour_2', 'hour_3') if date.get(key)]
                 if hour:
                     new_date = new_date.replace(hour=int(max(hour)), minute=0, second=0)
-                    am = [date.get(key) for key in ('am', 'am_1') if date.get(key)]
-                    if am and max(am) in ('p', 'pm'):
-                        h = int(max(hour))
-                        if h < 12:
-                            new_date = new_date.replace(hour=h+12)
+                    am_pm = [date.get(key) for key in ('am', 'am_1') if date.get(key)]
+                    if am_pm:
+                        self._specified.daytime = True
+                        if max(am_pm) in ('p', 'pm'):
+                            h = int(max(hour))
+                            if h < 12:
+                                new_date = new_date.replace(hour=h+12)
                     # No offset because the hour was set.
                     offset = False
                     self._specified.hour = True

--- a/timestring/Date.py
+++ b/timestring/Date.py
@@ -154,13 +154,13 @@ class Date(object):
                             if iso <= new_date.isoweekday():
                                 days += 7
                         new_date += timedelta(days=days)
-                        self._specified = Specified(1, 1, 1, 0, 0, 0, 0)
+                        self._specified.day = True  # TODO more fine-grained
                 elif relative_day:
                     days = RELATIVE_DAYS.get(re.sub(r'\s+', ' ', relative_day))
                     if days:
                         new_date += timedelta(days=days)
                     new_date = new_date.replace(hour=0, minute=0, second=0, microsecond=0)
-                    self._specified = Specified(1, 1, 1, 0, 0, 0, 0)
+                    self._specified.day = True
 
                 # Year
                 year = [int(CLEAN_NUMBER.sub('', date[key])) for key in ('year', 'year_2', 'year_3', 'year_4', 'year_5', 'year_6') if date.get(key)]
@@ -216,7 +216,7 @@ class Date(object):
                                                     microsecond=0)
                     # No offset because the hour was set.
                     offset = False
-                    self._specified.hour = True
+                    self._specified.hour = True  # TODO am/pm
 
                 # Hour
                 hour = [date.get(key) for key in ('hour', 'hour_2', 'hour_3') if date.get(key)]

--- a/timestring/timestring_re.py
+++ b/timestring/timestring_re.py
@@ -72,9 +72,9 @@ TIMESTRING_RE = re.compile(re.sub('[\t\n\s]', '', re.sub('(\(\?\#[^\)]+\))', '',
                         (?P<time_2>
                             ((?P<hour>[012]?[0-9]):(?P<minute>[0-5]\d)\s*(?P<am>am|pm|p|a))
                                 |
-                            ((?P<hour_2>[012]?[0-9]):(?P<minute_2>[0-5]\d)(:(?P<seconds>[0-5]\d))?)
+                            ((?P<hour_2>[012]?[0-9]):(?P<minute_2>[0-5]\d)(:(?P<seconds>[0-5]\d))?)\s*(?P<am_2>am|pm|p|a)?
                                 |
-                            ((?P<hour_3>[012]?[0-9])\s*(?P<am_1>am|pm|p|a|o'?clock))
+                            ((?P<hour_3>[012]?[0-9])\s*((?P<am_1>am|pm|p|a)|o'?clock))
                                 |
                             (?P<daytime>(after)?noon|morning|((around|about|near|by)\s+)?this\s+time|evening|(mid)?night(time)?)
                         )


### PR DESCRIPTION
Record what part of the time was specified by the user. This is needed for https://iamplus.atlassian.net/browse/AE-5159.

This solution uses output flags to describe the state of all components of a date and time reference (year, month, hour ,etc.) as either specified or not. This is similar to `parsedatetime`.

The specified fields are represented using a new class. This is convenient but takes space. Should we use a binary representation like `5` = `0000110` to represent that just hour and minute were specified?

Required for https://github.com/iAmPlus/aneeda/pull/1351